### PR TITLE
modernizing example code for the objectmapper Java example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # Object Mapper in Java
-The [Java DataStax Driver](https://docs.datastax.com/en/developer/java-driver/latest/) comes with an object mapper that removes boilerplate of writing queries and lets you focus on your application objects. This example shows how to use mapper to build Data Access Objects ( DAOs ) to access Apache Cassandra™ in a Java application.
+The [Java DataStax Driver](https://docs.datastax.com/en/developer/java-driver/latest/) comes with an object mapper that removes boilerplate of writing queries 
+and lets you focus on your application objects. This example shows how to use mapper to build Data Access Objects ( DAOs ) to access Apache Cassandra™ in a Java 
+application.
 
-Contributor(s): [Olivier Michallat](https://github.com/olim7t) - derived from [here](https://github.com/datastax/java-driver/tree/4.x/examples/src/main/java/com/datastax/oss/driver/examples/mapper)
+Contributor(s): [Olivier Michallat](https://github.com/olim7t) - derived from 
+[here](https://github.com/datastax/java-driver/tree/4.x/examples/src/main/java/com/datastax/oss/driver/examples/mapper)
 
 ## Objectives
 
-* Demonstrate how to use the Java Driver object mapper to replace the tedious work of DAO recreation in Java. Reference the [documentation](https://docs.datastax.com/en/developer/java-driver/latest/manual/mapper/mapper/) for details about the object mapper.
+* Demonstrate how to use the Java Driver object mapper to replace the tedious work of DAO recreation in Java. Reference the 
+[documentation](https://docs.datastax.com/en/developer/java-driver/latest/manual/mapper/mapper/) for details about the object mapper.
   
 ## Project Layout
 
-* [MapperApp.java](/src/main/java/com/datastax/examples/MapperApp.java) - The main application file that uses the [`video`](/src/main/java/com/datastax/examples/mapper/killrvideo/video/) and [`user`](/src/main/java/com/datastax/examples/mapper/killrvideo/user/) DAOs.
+* [MapperApp.java](/src/main/java/com/datastax/examples/MapperApp.java) - The main application file that uses the 
+[`video`](/src/main/java/com/datastax/examples/mapper/killrvideo/video/) and [`user`](/src/main/java/com/datastax/examples/mapper/killrvideo/user/) DAOs.
 
 ## How this Sample Works
 The driver provides a simple object mapper which allows us to avoid writing much of the boilerplate code 
 required to map query results to and from POJOs.
 
-To use the mapper requires that several different components be annotated in such a way as to allow them to 
+To use the mapper requires that several components be annotated in such a way as to allow them to 
 work together:
 
 * Mapper - This is the entry point for this mapper which wraps the core driver session and acts as a factory for 
@@ -33,34 +38,40 @@ In this example
 [LoginQueryProvider](/src/main/java/com/datastax/examples/mapper/killrvideo/user/LoginQueryProvider.java) and 
 [CreateUserQueryProvider](/src/main/java/com/datastax/examples/mapper/killrvideo/user/CreateUserQueryProvider.java) are Query Provider classes.
 
-For additional information and details on how to use the Mapper classes please refer to the documentation available [here](https://docs.datastax.com/en/developer/java-driver/4.3/manual/mapper/).
+For additional information and details on how to use the Mapper classes please refer to the documentation available 
+[here](https://docs.datastax.com/en/developer/java-driver/4.3/manual/mapper/).
  
 ## Setup and Running
 
 ### Prerequisites
 
-* Java 8
+* JDK 14
 * A Cassandra cluster is running and accessible through the contacts points and data center identified in [application.conf](/src/main/resources/application.conf)
+#### Building
+At the project root level
 
-### Running
+```mvn clean package```
 
-To run this application use the following command:
+This builds the JAR file located at `target/object-mapper-1.0.jar`
 
-`mvn exec:java -Dexec.mainClass=com.datastax.examples.MapperApp`
+#### Run the program
+To run this application, use the following command:
+
+```java -jar target/object-mapper-1.0.jar```
 
 This will produce results similar to those below.
 
 ```
-Reusing existing User[userid=1c8612ce-3ff9-4741-9c29-5f63bbe5d9d4, firstname='test', lastname='user', email='testuser@example.com', createdDate=2019-11-15T17:19:54.129Z]
+Created User[userid=ce662229-e371-4469-843a-b3e16d9fb8fa, firstname='test', lastname='user', email='testuser@example.com', createdDate=2020-04-16T20:37:17.596601Z]
 Logging in with testuser@example.com/password123: Success
 Logging in with testuser@example.com/secret123: Failure
-Created video [79d302e0-3261-460a-849f-3db992e79899] Join us at DataStax Accelerate 2020
+Created video [d40e409e-4949-4728-89dc-a4374ee78b17] Accelerate: A NoSQL Original Series (TRAILER)
 Videos for test user:
-  [79d302e0-3261-460a-849f-3db992e79899] Join us at DataStax Accelerate 2020
+  [d40e409e-4949-4728-89dc-a4374ee78b17] Accelerate: A NoSQL Original Series (TRAILER)
 Latest videos:
-  [79d302e0-3261-460a-849f-3db992e79899] Join us at DataStax Accelerate 2020
+  [d40e409e-4949-4728-89dc-a4374ee78b17] Accelerate: A NoSQL Original Series (TRAILER)
 Videos tagged with apachecassandra:
-  [558e036d-a5df-4e1c-9309-e3048d5c34fb] Join us at DataStax Accelerate 2020
-Updated name for video 79d302e0-3261-460a-849f-3db992e79899: Join us at DataStax Accelerate 2020, in sunny San Diego!
+  [d40e409e-4949-4728-89dc-a4374ee78b17] Accelerate: A NoSQL Original Series (TRAILER)
+Updated name for video d40e409e-4949-4728-89dc-a4374ee78b17: Accelerate: A NoSQL Original Series - join us online!
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.datastax.examples</groupId>
   <artifactId>object-mapper</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0</version>
 
   <properties>
     <datastax-driver.version>4.3.0</datastax-driver.version>
@@ -34,7 +34,11 @@
       <artifactId>bcrypt</artifactId>
       <version>0.7.0</version>
     </dependency>
-
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -43,26 +47,33 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>14</source>
+          <target>14</target>
         </configuration>
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <!-- automatically creates the classpath using all project dependencies,
-                also adding the project build directory -->
-            <classpath />
-            <argument>com.datastax.examples.MapperApp</argument>
-          </arguments>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>com.datastax.examples.MapperApp</mainClass>
+            </manifest>
+          </archive>
+          <finalName>${artifactId}-${version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
         </configuration>
-
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/datastax/examples/MapperApp.java
+++ b/src/main/java/com/datastax/examples/MapperApp.java
@@ -15,8 +15,10 @@
  */
 package com.datastax.examples;
 
+import com.datastax.examples.mapper.killrvideo.KillrVideoMapper;
 import com.datastax.examples.mapper.killrvideo.user.User;
 import com.datastax.examples.mapper.killrvideo.user.UserDao;
+import com.datastax.examples.mapper.killrvideo.video.LatestVideo;
 import com.datastax.examples.mapper.killrvideo.video.UserVideo;
 import com.datastax.examples.mapper.killrvideo.video.Video;
 import com.datastax.examples.mapper.killrvideo.video.VideoByTag;
@@ -25,12 +27,9 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.examples.mapper.killrvideo.KillrVideoMapper;
-import com.datastax.examples.mapper.killrvideo.video.LatestVideo;
 
 import java.net.URI;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,6 +39,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -114,9 +114,8 @@ public class MapperApp {
 
       Video video = new Video();
       video.setUserid(user.getUserid());
-      video.setName(
-          "Join us at DataStax Accelerate 2020");
-      video.setLocation("https://www.youtube.com/watch?v=P5pV-vAahYU");
+      video.setName("Accelerate: A NoSQL Original Series (TRAILER)");
+      video.setLocation("https://www.youtube.com/watch?v=LulWy8zmrog");
       Set<String> tags = new HashSet<>();
       tags.add("apachecassandra");
       tags.add("nosql");
@@ -149,7 +148,7 @@ public class MapperApp {
       Video template = new Video();
       template.setVideoid(video.getVideoid());
       template.setName(
-          "Join us at DataStax Accelerate 2020, in sunny San Diego!");
+          "Accelerate: A NoSQL Original Series - join us online!");
       videoDao.update(template);
       // Reload the whole entity and check the fields
       video = videoDao.get(video.getVideoid());
@@ -179,16 +178,11 @@ public class MapperApp {
   }
 
   private static List<String> getStatements(String fileName) throws Exception {
-    URL url = null;
-    try{
-      url = ClassLoader.getSystemResource(fileName);
-    } catch(Throwable t){
-      t.printStackTrace();
-    }
-    URI uri = url.toURI();
-    Path path = Paths.get(ClassLoader.getSystemResource(fileName).toURI());
+    URI uri = Thread.currentThread().getContextClassLoader().getResource(fileName).toURI();
+    FileSystems.newFileSystem(uri, Map.of("create", "true"));
+    Path path = Paths.get(uri);
 
-    String contents = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    String contents = Files.readString(path);
     return Arrays.stream(contents.split(";"))
         .map(String::trim)
         .filter(s -> !s.isEmpty())

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -32,6 +32,6 @@
     <!-- adjust the driver's log verbosity; see
     https://docs.datastax.com/en/developer/java-driver/4.0/manual/core/logging/
     for more information -->
-    <logger name="com.datastax.oss.driver" level="INFO"/>
+    <logger name="com.datastax.oss.driver" level="WARN"/>
 
 </configuration>


### PR DESCRIPTION
DataStax Desktop uses this and two other examples to help users get to know C*/DSE.

I came here to:
* clean up the instructions
* update to latest JDK release (Java 8 is EOL, so we probably shouldn't use it in our examples)
* simplify and make consistent the process of building and running the three examples in question

I also:
* updated the code to use pure NIO with no legacy java.io stuff.
* updated the example to use a different video, since Accelerate 2020: San Diego is no longer a thing.